### PR TITLE
MUSUNDirectory and safety update

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,12 @@ Macros to controll the primary generator
 /WLGD/generator/
   - depth
   - setMUSUNFile (path to file)
+  - setMUSUNDirectory (full path to directory containing MUSUN files)
   - setGenerator (options: "MeiAndHume", "Musun", "Ge77m", "Ge77andGe77m", "ModeratorNeutrons", "ExternalNeutrons")
 ```
+
+More information on SetMUSUNDirectory can be found in the OpenMUSUNDirectory method of src/WLGDPrimaryGeneratorAction.cc
+
 ### Detector Macro
 Macros to controll the detector geometry
 ```

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     //WLGDPrimaryGeneratorAction::ChangeFileName("./musun_gs_100M.dat");
     // command line interface
     CLI::App    app{ "Muon Simulation for Legend" };
-    int         nthreads = 4;
+    int         nthreads = 1;
     std::string outputFileName("lg.root");
     std::string macroName;
 


### PR DESCRIPTION
Added new input file option 'setMUSUNDirectory'. Changed default number of threads to 1 for safety. Altered a variable name in the PrimaryGenerator which contained an accented character that was incompatible with some machines.